### PR TITLE
fix:修正一处引用错误

### DIFF
--- a/assets/minecraft/sounds.json
+++ b/assets/minecraft/sounds.json
@@ -67,7 +67,7 @@
             "tianyi/bjbs",
             "tianyi/fxfx",
             "tianyi/lost08",
-            "tianyi/sfxs",
+            "tianyi/sfks",
             "tianyi/sr",
             "tianyi/zdh",
             "tianyi/dramatic",


### PR DESCRIPTION
将"sounds.json"文件中的 'tianyi/sfxs' 替换为 'tianyi/sfks' 以修复《斯芬克斯的谜底》在主界面中无法播放的问题
<img width="655" height="73" alt="屏幕截图 2026-01-07 151124" src="https://github.com/user-attachments/assets/30b143ec-a65c-438b-b360-5f6f6dabf35d" />
<img width="1281" height="1529" alt="屏幕截图 2026-01-07 152214" src="https://github.com/user-attachments/assets/f567e172-9510-42fe-80b4-2320a533a070" />
<img width="1281" height="1530" alt="屏幕截图 2026-01-07 152242" src="https://github.com/user-attachments/assets/50e74879-9017-4787-90b6-0dd5a65a1488" />
